### PR TITLE
Fix font usage of image model

### DIFF
--- a/src/CovertActionTools.App/Windows/SelectedFontWindow.cs
+++ b/src/CovertActionTools.App/Windows/SelectedFontWindow.cs
@@ -111,16 +111,15 @@ public class SelectedFontWindow : BaseWindow
             
             var ox = x + fontMetadata.HorizontalPadding;
             var oy = y + fontMetadata.VerticalPadding;
-            var imageBytes = font.CharacterImages[charToUse];
+            var image = font.CharacterImages[charToUse];
             var width = fontMetadata.CharacterWidths[charToUse];
             var height = fontMetadata.CharHeight;
-            
-            using var skBitmap = SKBitmap.Decode(imageBytes, new SKImageInfo(width, height, SKColorType.Rgba8888, SKAlphaType.Premul));
-            var image = skBitmap.Bytes.ToArray();
+
+            var imageBytes = image.VgaImageData;
             
             ImGui.SetCursorPos(pos + new Vector2(ox, oy));
             var id = $"font_{fontId}_{(byte)charToUse}";
-            var texture = _renderWindow.RenderImage(RenderWindow.RenderType.Image, id, width, height, image);
+            var texture = _renderWindow.RenderImage(RenderWindow.RenderType.Image, id, width, height, imageBytes);
             ImGui.Image(texture, new Vector2(width, height));
 
             x += width + fontMetadata.HorizontalPadding;
@@ -137,16 +136,15 @@ public class SelectedFontWindow : BaseWindow
         {
             var ox = x + fontMetadata.HorizontalPadding;
             var oy = y + fontMetadata.VerticalPadding;
-            var imageBytes = font.CharacterImages[(char)code];
+            var image = font.CharacterImages[(char)code];
             var width = fontMetadata.CharacterWidths[(char)code];
             var height = fontMetadata.CharHeight;
 
-            using var skBitmap = SKBitmap.Decode(imageBytes, new SKImageInfo(width, height, SKColorType.Rgba8888, SKAlphaType.Premul));
-            var image = skBitmap.Bytes.ToArray();
+            var imageBytes = image.VgaImageData;
             
             ImGui.SetCursorPos(pos + new Vector2(ox, oy));
             var id = $"font_{fontId}_{code}";
-            var texture = _renderWindow.RenderImage(RenderWindow.RenderType.Image, id, width, height, image);
+            var texture = _renderWindow.RenderImage(RenderWindow.RenderType.Image, id, width, height, imageBytes);
             ImGui.Image(texture, new Vector2(width, height));
 
             i++;

--- a/src/CovertActionTools.Core/Exporting/Exporters/FontsExporter.cs
+++ b/src/CovertActionTools.Core/Exporting/Exporters/FontsExporter.cs
@@ -2,6 +2,7 @@
 using System.IO;
 using System.Text;
 using System.Text.Json;
+using CovertActionTools.Core.Exporting.Shared;
 using CovertActionTools.Core.Importing;
 using CovertActionTools.Core.Models;
 using Microsoft.Extensions.Logging;
@@ -25,12 +26,14 @@ namespace CovertActionTools.Core.Exporting.Exporters
 #endif
         
         private readonly ILogger<FontsExporter> _logger;
+        private readonly SharedImageExporter _imageExporter;
         
         private bool _done = false;
 
-        public FontsExporter(ILogger<FontsExporter> logger)
+        public FontsExporter(ILogger<FontsExporter> logger, SharedImageExporter imageExporter)
         {
             _logger = logger;
+            _imageExporter = imageExporter;
         }
 
         protected override string Message => "Processing fonts..";
@@ -90,7 +93,8 @@ namespace CovertActionTools.Core.Exporting.Exporters
                 foreach (var c in font.CharacterImages.Keys)
                 {
                     var code = (byte)c;
-                    dict[$"FONTS_{f}_{code}.png"] = font.CharacterImages[c];
+                    dict[$"FONTS_{f}_{code}_VGA_metadata.json"] = _imageExporter.GetImageData(font.CharacterImages[c]);
+                    dict[$"FONTS_{f}_{code}_VGA.png"] = _imageExporter.GetVgaImageData(font.CharacterImages[c]);
                 }
             }
 

--- a/src/CovertActionTools.Core/Exporting/Publishers/FontsPublisher.cs
+++ b/src/CovertActionTools.Core/Exporting/Publishers/FontsPublisher.cs
@@ -92,19 +92,17 @@ namespace CovertActionTools.Core.Exporting.Publishers
                 var fontStrings = new Dictionary<char, List<string>>();
                 foreach (var c in fonts.Fonts[fontId].CharacterImages.Keys)
                 {
-                    var imageData = fonts.Fonts[fontId].CharacterImages[c];
+                    var image = fonts.Fonts[fontId].CharacterImages[c];
                     var width = fontMetadata.CharacterWidths[c];
                     var height = fontMetadata.CharHeight;
-                    using var skBitmap = SKBitmap.Decode(imageData, new SKImageInfo(width, height, SKColorType.Rgba8888, SKAlphaType.Premul));
+                    var bytes = image.RawVgaImageData;
                     var lines = new List<string>();
                     for (var i = 0; i < height; i++)
                     {
                         var s = "";
                         for (var j = 0; j < width; j++)
                         {
-                            var col = skBitmap.GetPixel(j, i);
-                            var transparent = !((col.Red > 0 || col.Green > 0 || col.Blue > 0) && col.Alpha > 0);
-                            if (transparent)
+                            if (bytes[i*width + j] == 0)
                             {
                                 s += " ";
                             }

--- a/src/CovertActionTools.Core/Importing/Parsers/LegacyFontsParser.cs
+++ b/src/CovertActionTools.Core/Importing/Parsers/LegacyFontsParser.cs
@@ -150,10 +150,10 @@ namespace CovertActionTools.Core.Importing.Parsers
                     }
                 }
 
-                var charImageData = new Dictionary<char, byte[]>();
+                var charImageData = new Dictionary<char, SharedImageModel>();
                 foreach (var c in charFontData.Keys)
                 {
-                    var imageData = new byte[charWidths[c] * charHeight * 4];
+                    var imageData = new byte[charWidths[c] * charHeight];
                     var fontData = charFontData[c];
                     var q = 0;
                     
@@ -163,15 +163,20 @@ namespace CovertActionTools.Core.Importing.Parsers
                         for (var j = 0; j < line.Length; j++)
                         {
                             var transparent = line[j] == ' ';
-                            imageData[q++] = (byte)(transparent ? 0 : 255);
-                            imageData[q++] = (byte)(transparent ? 0 : 255);
-                            imageData[q++] = (byte)(transparent ? 0 : 255);
-                            imageData[q++] = (byte)(transparent ? 0 : 255);
+                            imageData[q++] = (byte)(transparent ? 0 : 15);
                         }
                     }
 
-                    var texture = ImageConversion.RgbaToTexture(charWidths[c], charHeight, imageData);
-                    charImageData[c] = texture;
+                    charImageData[c] = new SharedImageModel()
+                    {
+                        Data = new SharedImageModel.ImageData()
+                        {
+                            Width = charWidths[c],
+                            Height = charHeight,
+                        },
+                        RawVgaImageData = imageData,
+                        VgaImageData = ImageConversion.VgaToTexture(charWidths[c], charHeight, imageData)
+                    };
                 }
 
                 fonts.Data.Fonts[f] = new FontsModel.FontMetadata()

--- a/src/CovertActionTools.Core/Models/FontsModel.cs
+++ b/src/CovertActionTools.Core/Models/FontsModel.cs
@@ -7,7 +7,7 @@ namespace CovertActionTools.Core.Models
     {
         public class Font
         {
-            public Dictionary<char, byte[]> CharacterImages { get; set; } = new();
+            public Dictionary<char, SharedImageModel> CharacterImages { get; set; } = new();
         }
 
         public class FontMetadata
@@ -53,7 +53,7 @@ namespace CovertActionTools.Core.Models
                 },
                 Fonts = Fonts.Select(x => new Font()
                 {
-                    CharacterImages = x.CharacterImages.ToDictionary(x => x.Key, x => x.Value.ToArray())
+                    CharacterImages = x.CharacterImages.ToDictionary(y => y.Key, y => y.Value.Clone())
                 }).ToList()
             };
         }


### PR DESCRIPTION
Makes fonts use image model instead of using byte arrays of converted images directly.