### PR TITLE
Start implementing sprite sheet handling

### DIFF
--- a/src/CovertActionTools.App/ViewModels/ImageEditorState.cs
+++ b/src/CovertActionTools.App/ViewModels/ImageEditorState.cs
@@ -1,0 +1,7 @@
+﻿namespace CovertActionTools.App.ViewModels;
+
+public class ImageEditorState : IViewModel
+{
+    public bool ShowSprites { get; set; } = true;
+    public bool ShowSpriteNames { get; set; } = true;
+}

--- a/src/CovertActionTools.App/Windows/SelectedAnimationWindow.cs
+++ b/src/CovertActionTools.App/Windows/SelectedAnimationWindow.cs
@@ -19,7 +19,7 @@ public class SelectedAnimationWindow : SharedImageWindow
     private int _selectedImage = 0;
     private int _selectedSprite = 0;
 
-    public SelectedAnimationWindow(RenderWindow renderWindow, ILogger<SelectedAnimationWindow> logger, MainEditorState mainEditorState, IAnimationProcessor animationProcessor, AnimationPreviewState animationPreviewState, AnimationEditorState animationEditorState, PendingEditorAnimationState pendingState) : base(renderWindow)
+    public SelectedAnimationWindow(RenderWindow renderWindow, ILogger<SelectedAnimationWindow> logger, MainEditorState mainEditorState, IAnimationProcessor animationProcessor, AnimationPreviewState animationPreviewState, AnimationEditorState animationEditorState, PendingEditorAnimationState pendingState, ImageEditorState editorState) : base(renderWindow, editorState)
     {
         _logger = logger;
         _mainEditorState = mainEditorState;
@@ -524,7 +524,7 @@ public class SelectedAnimationWindow : SharedImageWindow
             return;
         }
 
-        DrawImageTabs($"{animation.Key}_{selectedIndex}", image, () => { });
+        DrawImageTabs($"{animation.Key}_{selectedIndex}", image, () => { }, null);
     }
     
     private string GetInstructionText(int index, AnimationModel.AnimationInstruction instruction)

--- a/src/CovertActionTools.App/Windows/SelectedCatalogImageWindow.cs
+++ b/src/CovertActionTools.App/Windows/SelectedCatalogImageWindow.cs
@@ -12,7 +12,7 @@ public class SelectedCatalogImageWindow : SharedImageWindow
     private readonly MainEditorState _mainEditorState;
     private readonly PendingEditorCatalogState _pendingState;
 
-    public SelectedCatalogImageWindow(ILogger<SelectedCatalogImageWindow> logger, MainEditorState mainEditorState, RenderWindow renderWindow, PendingEditorCatalogState pendingState) : base(renderWindow)
+    public SelectedCatalogImageWindow(ILogger<SelectedCatalogImageWindow> logger, MainEditorState mainEditorState, RenderWindow renderWindow, PendingEditorCatalogState pendingState, ImageEditorState editorState) : base(renderWindow, editorState)
     {
         _logger = logger;
         _mainEditorState = mainEditorState;
@@ -89,6 +89,6 @@ public class SelectedCatalogImageWindow : SharedImageWindow
 
     private void DrawImageWindow(PackageModel model, CatalogModel catalog, string imageId, SharedImageModel image)
     {
-        DrawImageTabs($"{catalog.Key}_{imageId}", image, () => { _pendingState.RecordChange(); });
+        DrawImageTabs($"{catalog.Key}_{imageId}", image, () => { _pendingState.RecordChange(); }, null);
     }
 }

--- a/src/CovertActionTools.App/Windows/SelectedSimpleImageWindow.cs
+++ b/src/CovertActionTools.App/Windows/SelectedSimpleImageWindow.cs
@@ -12,7 +12,7 @@ public class SelectedSimpleImageWindow : SharedImageWindow
     private readonly MainEditorState _mainEditorState;
     private readonly PendingEditorSimpleImageState _pendingState;
 
-    public SelectedSimpleImageWindow(ILogger<SelectedSimpleImageWindow> logger, MainEditorState mainEditorState, RenderWindow renderWindow, PendingEditorSimpleImageState pendingState) : base(renderWindow)
+    public SelectedSimpleImageWindow(ILogger<SelectedSimpleImageWindow> logger, MainEditorState mainEditorState, RenderWindow renderWindow, PendingEditorSimpleImageState pendingState, ImageEditorState editorState) : base(renderWindow, editorState)
     {
         _logger = logger;
         _mainEditorState = mainEditorState;
@@ -79,6 +79,21 @@ public class SelectedSimpleImageWindow : SharedImageWindow
         
         DrawSharedMetadataEditor(image.Metadata, () => { _pendingState.RecordChange(); });
         
-        DrawImageTabs(key, image.Image, () => { _pendingState.RecordChange(); });
+        DrawImageTabs(key, image.Image, () => { _pendingState.RecordChange(); }, (enabled) =>
+        {
+            if (enabled)
+            {
+                image.SpriteSheet = new SimpleImageModel.SpriteSheetData()
+                {
+                    Sprites = new Dictionary<string, SimpleImageModel.Sprite>()
+                };
+            }
+            else
+            {
+                image.SpriteSheet = null;
+            }
+
+            _pendingState.RecordChange();
+        }, spriteSheet: image.SpriteSheet);
     }
 }

--- a/src/CovertActionTools.App/Windows/SharedImageWindow.cs
+++ b/src/CovertActionTools.App/Windows/SharedImageWindow.cs
@@ -1,4 +1,5 @@
 ﻿using System.Numerics;
+using CovertActionTools.App.ViewModels;
 using CovertActionTools.Core.Models;
 using ImGuiNET;
 
@@ -7,19 +8,21 @@ namespace CovertActionTools.App.Windows;
 public abstract class SharedImageWindow : BaseWindow
 {
     protected readonly RenderWindow RenderWindow;
+    protected readonly ImageEditorState EditorState;
 
-    protected SharedImageWindow(RenderWindow renderWindow)
+    protected SharedImageWindow(RenderWindow renderWindow, ImageEditorState editorState)
     {
         RenderWindow = renderWindow;
+        EditorState = editorState;
     }
 
-    protected void DrawImageTabs(string key, SharedImageModel image, Action recordChange)
+    protected void DrawImageTabs(string key, SharedImageModel image, Action recordChange, Action<bool>? toggleSpriteSheet, SimpleImageModel.SpriteSheetData? spriteSheet = null)
     {
         ImGui.BeginTabBar("ImageTabs", ImGuiTabBarFlags.NoCloseWithMiddleMouseButton);
 
         if (ImGui.BeginTabItem("VGA"))
         {
-            DrawVgaImageTab(key, image, recordChange);
+            DrawVgaImageTab(key, image, recordChange, toggleSpriteSheet, spriteSheet);
             
             ImGui.EndTabItem();
         }
@@ -74,7 +77,118 @@ public abstract class SharedImageWindow : BaseWindow
         }
     }
 
-    private void DrawVgaImageTab(string key, SharedImageModel image, Action recordChange)
+    private void DrawVgaImageTab(string key, SharedImageModel image, 
+        Action recordChange, Action<bool>? toggleSpriteSheet,
+        SimpleImageModel.SpriteSheetData? spriteSheet = null)
+    {
+        if (ImGui.BeginTable("vga", 2))
+        {
+            ImGui.TableSetupColumn("image", ImGuiTableColumnFlags.WidthFixed);
+            ImGui.TableSetupColumn("menu", ImGuiTableColumnFlags.WidthStretch);
+            ImGui.TableNextRow();
+            ImGui.TableNextColumn();
+            DrawVgaImage(key, image, recordChange, spriteSheet);
+            
+            ImGui.TableNextColumn();
+            if (toggleSpriteSheet != null)
+            {
+                var hasSpriteSheet = spriteSheet != null;
+                var newHasSpriteSheet = ImGuiExtensions.Input("Is Sprite Sheet?", hasSpriteSheet);
+                if (newHasSpriteSheet != null)
+                {
+                    toggleSpriteSheet(newHasSpriteSheet.Value);
+                }
+                else
+                {
+                    if (spriteSheet != null)
+                    {
+                        if (ImGui.Button("Add Sprite"))
+                        {
+                            spriteSheet.Sprites.Add("", new SimpleImageModel.Sprite());
+                            recordChange();
+                        }
+
+                        var newShowSprites = ImGuiExtensions.Input("Show sprites?", EditorState.ShowSprites);
+                        if (newShowSprites != null)
+                        {
+                            EditorState.ShowSprites = newShowSprites.Value;
+                        }
+
+                        var newShowSpriteNames =
+                            ImGuiExtensions.Input("Show sprite names?", EditorState.ShowSpriteNames);
+                        if (newShowSpriteNames != null)
+                        {
+                            EditorState.ShowSpriteNames = newShowSpriteNames.Value;
+                        }
+
+                        if (ImGui.BeginTable("sprites", 6))
+                        {
+                            var spriteKeys = spriteSheet.Sprites.Keys.ToList();
+                            foreach (var spriteKey in spriteKeys)
+                            {
+                                var sprite = spriteSheet.Sprites[spriteKey];
+                                ImGui.TableNextRow();
+                                ImGui.TableNextColumn();
+
+                                var newSpriteKey = ImGuiExtensions.Input("Key", spriteKey, 64);
+                                if (!string.IsNullOrEmpty(newSpriteKey))
+                                {
+                                    spriteSheet.Sprites[newSpriteKey] = sprite;
+                                    spriteSheet.Sprites.Remove(spriteKey);
+                                    recordChange();
+                                }
+
+                                ImGui.TableNextColumn();
+                                var newX = ImGuiExtensions.Input("X", sprite.X);
+                                if (newX != null)
+                                {
+                                    sprite.X = newX.Value;
+                                    recordChange();
+                                }
+                                
+                                ImGui.TableNextColumn();
+                                var newY = ImGuiExtensions.Input("Y", sprite.Y);
+                                if (newY != null)
+                                {
+                                    sprite.Y = newY.Value;
+                                    recordChange();
+                                }
+                                
+                                ImGui.TableNextColumn();
+                                var newW = ImGuiExtensions.Input("W", sprite.Width);
+                                if (newW != null)
+                                {
+                                    sprite.Width = newW.Value;
+                                    recordChange();
+                                }
+                                
+                                ImGui.TableNextColumn();
+                                var newH = ImGuiExtensions.Input("H", sprite.Height);
+                                if (newH != null)
+                                {
+                                    sprite.Height = newH.Value;
+                                    recordChange();
+                                }
+                                
+                                ImGui.TableNextColumn();
+                                if (ImGui.Button("Remove"))
+                                {
+                                    spriteSheet.Sprites.Remove(spriteKey);
+                                    recordChange();
+                                }
+                            }
+                            
+                            ImGui.EndTable();
+                        }
+                    }
+                }
+            }
+            
+            ImGui.EndTable();
+        }
+    }
+
+    private void DrawVgaImage(string key, SharedImageModel image, Action recordChange, SimpleImageModel.SpriteSheetData? spriteSheet = null)
     {
         var width = image.Data.Width;
         var height = image.Data.Height;
@@ -88,8 +202,26 @@ public abstract class SharedImageWindow : BaseWindow
         ImGui.SetCursorPos(pos);
         var id = $"image_vga_{key}";
         var texture = RenderWindow.RenderImage(RenderWindow.RenderType.Image, id, width, height, rawPixels);
-        
         ImGui.Image(texture, new Vector2(width, height));
+    
+        if (spriteSheet != null && EditorState.ShowSprites)
+        {
+            foreach (var pair in spriteSheet.Sprites)
+            {
+                var spriteKey = pair.Key;
+                var sprite = pair.Value;
+            
+                ImGui.SetCursorPos(pos + new Vector2(sprite.X - 1, sprite.Y - 1));
+                var spriteOverlay = RenderWindow.RenderOutlineRectangle(1, sprite.Width + 2, sprite.Height + 2, (128, 255, 255, 255));
+                ImGui.Image(spriteOverlay, new Vector2(sprite.Width + 2, sprite.Height + 2));
+
+                if (EditorState.ShowSpriteNames)
+                {
+                    ImGui.SetCursorPos(pos + new Vector2(sprite.X, sprite.Y + sprite.Height - ImGui.GetTextLineHeight()));
+                    ImGui.Text(spriteKey);
+                }
+            }
+        }
     }
     
     private void DrawCgaImageTab(string key, SharedImageModel image, Action recordChange)

--- a/src/CovertActionTools.Core/Exporting/Exporters/SimpleImageExporter.cs
+++ b/src/CovertActionTools.Core/Exporting/Exporters/SimpleImageExporter.cs
@@ -94,12 +94,23 @@ namespace CovertActionTools.Core.Exporting.Exporters
                 [$"{image.Key}_metadata.json"] = GetMetadata(image),
                 [$"{image.Key}_VGA.png"] = _imageExporter.GetVgaImageData(image.Image) 
             };
+            if (image.SpriteSheet != null && image.SpriteSheet.Sprites.Count > 0)
+            {
+                dict[$"{image.Key}_sprites.json"] = GetSpriteSheet(image);
+            }
             return dict;
         }
         
         private byte[] GetMetadata(SimpleImageModel image)
         {
             var data = JsonSerializer.Serialize(image.Metadata, JsonOptions);
+            var bytes = Encoding.UTF8.GetBytes(data);
+            return bytes;
+        }
+        
+        private byte[] GetSpriteSheet(SimpleImageModel image)
+        {
+            var data = JsonSerializer.Serialize(image.SpriteSheet, JsonOptions);
             var bytes = Encoding.UTF8.GetBytes(data);
             return bytes;
         }

--- a/src/CovertActionTools.Core/Importing/Importers/SimpleImageImporter.cs
+++ b/src/CovertActionTools.Core/Importing/Importers/SimpleImageImporter.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Text.Json;
 using CovertActionTools.Core.Conversion;
 using CovertActionTools.Core.Importing.Shared;
 using CovertActionTools.Core.Models;
@@ -83,7 +84,28 @@ namespace CovertActionTools.Core.Importing.Importers
             model.Key = filename;
             model.Metadata = _imageImporter.ReadMetadata(path, filename, "metadata");
             model.Image = _imageImporter.ReadImage(path, filename, "image");
+            if (File.Exists(System.IO.Path.Combine(path, $"{filename}_sprites.json")))
+            {
+                model.SpriteSheet = ReadSpriteSheet(path, filename);
+            }
             return model;
+        }
+        
+        private SimpleImageModel.SpriteSheetData ReadSpriteSheet(string path, string key)
+        {
+            var filePath = System.IO.Path.Combine(path, $"{key}_sprites.json");
+            if (!File.Exists(filePath))
+            {
+                throw new Exception($"Missing JSON file: {key}");
+            }
+
+            var json = File.ReadAllText(filePath);
+            var data = JsonSerializer.Deserialize<SimpleImageModel.SpriteSheetData>(json);
+            if (data == null)
+            {
+                throw new Exception($"Unparseable JSON file: {key}");
+            }
+            return data;
         }
         
         private string GetPath(string path)

--- a/src/CovertActionTools.Core/Importing/Parsers/LegacySimpleImageParser.cs
+++ b/src/CovertActionTools.Core/Importing/Parsers/LegacySimpleImageParser.cs
@@ -10,6 +10,508 @@ namespace CovertActionTools.Core.Importing.Parsers
 {
     internal class LegacySimpleImageParser : BaseImporter<Dictionary<string, SimpleImageModel>>, ILegacyParser
     {
+        //TODO: figure out values for all sprite sheets to encode them
+        #region Legacy Data
+        private static readonly Dictionary<string, SimpleImageModel.SpriteSheetData> LegacySpriteSheets = new()
+        {
+            //"BUGS",
+            //"CAMERA",
+            //"CHASE",
+            {"EQUIP1", new SimpleImageModel.SpriteSheetData()
+                {
+                    //most sprites on the image are not used
+                    //bullets/magazines are duplicated
+                    //grenades are duplicated
+                    //boxes get highlighted by replacing colours, not by placing the sprite in
+                    Sprites = new Dictionary<string, SimpleImageModel.Sprite>()
+                    {
+                        { "gun_box", new SimpleImageModel.Sprite()
+                            {
+                                X = 2, Y = 15,
+                                Width = 61, Height = 25
+                            }
+                        },
+                        { "camera_box", new SimpleImageModel.Sprite()
+                            {
+                                X = 2, Y = 54,
+                                Width = 61, Height = 19
+                            }
+                        },
+                        { "bugs_box", new SimpleImageModel.Sprite()
+                            {
+                                X = 2, Y = 88,
+                                Width = 61, Height = 18
+                            }
+                        },
+                        { "grenades_frag_box", new SimpleImageModel.Sprite()
+                            {
+                                X = 2, Y = 122,
+                                Width = 61, Height = 17
+                            }
+                        },
+                        { "grenades_gas_box", new SimpleImageModel.Sprite()
+                            {
+                                X = 2, Y = 140,
+                                Width = 61, Height = 15
+                            }
+                        },
+                        { "grenades_flash_box", new SimpleImageModel.Sprite()
+                            {
+                                X = 2, Y = 156,
+                                Width = 61, Height = 15
+                            }
+                        },
+                        { "grenades_mix_box", new SimpleImageModel.Sprite()
+                            {
+                                X = 2, Y = 172,
+                                Width = 61, Height = 15
+                            }
+                        },
+                        { "gas_mask_box", new SimpleImageModel.Sprite()
+                            {
+                                X = 69, Y = 15,
+                                Width = 45, Height = 36
+                            }
+                        },
+                        { "motion_box", new SimpleImageModel.Sprite()
+                            {
+                                X = 116, Y = 15,
+                                Width = 42, Height = 36
+                            }
+                        },
+                        { "armor_box", new SimpleImageModel.Sprite()
+                            {
+                                X = 69, Y = 60,
+                                Width = 89, Height = 67
+                            }
+                        },
+                        { "safe_box", new SimpleImageModel.Sprite()
+                            {
+                                X = 69, Y = 136,
+                                Width = 89, Height = 45
+                            }
+                        },
+                        { "gun", new SimpleImageModel.Sprite()
+                            {
+                                X = 172, Y = 46,
+                                Width = 59, Height = 23
+                            }
+                        },
+                        { "pistol", new SimpleImageModel.Sprite()
+                            {
+                                X = 176, Y = 48,
+                                Width = 28, Height = 14
+                            }
+                        },
+                        { "camera", new SimpleImageModel.Sprite()
+                            {
+                                X = 221, Y = 75,
+                                Width = 25, Height = 22
+                            }
+                        },
+                        { "camera_text", new SimpleImageModel.Sprite()
+                            {
+                                X = 223, Y = 89,
+                                Width = 15, Height = 9
+                            }
+                        },
+                        { "bugs", new SimpleImageModel.Sprite()
+                            {
+                                X = 291, Y = 2,
+                                Width = 16, Height = 33
+                            }
+                        },
+                        { "grenade_frag", new SimpleImageModel.Sprite()
+                            {
+                                X = 175, Y = 0,
+                                Width = 9, Height = 13
+                            }
+                        },
+                        { "grenade_gas", new SimpleImageModel.Sprite()
+                            {
+                                X = 175, Y = 15,
+                                Width = 9, Height = 13
+                            }
+                        },
+                        { "grenade_flash", new SimpleImageModel.Sprite()
+                            {
+                                X = 175, Y = 30,
+                                Width = 9, Height = 13
+                            }
+                        },
+                        { "gas_mask", new SimpleImageModel.Sprite()
+                            {
+                                X = 253, Y = 2,
+                                Width = 38, Height = 31
+                            }
+                        },
+                        { "motion", new SimpleImageModel.Sprite()
+                            {
+                                X = 268, Y = 1,
+                                Width = 10, Height = 18
+                            }
+                        },
+                        { "armor", new SimpleImageModel.Sprite()
+                            {
+                                X = 253, Y = 29,
+                                Width = 48, Height = 62
+                            }
+                        },
+                        { "safe", new SimpleImageModel.Sprite()
+                            {
+                                X = 264, Y = 69,
+                                Width = 54, Height = 27
+                            }
+                        },
+                        { "bullet", new SimpleImageModel.Sprite()
+                            {
+                                X = 180, Y = 72,
+                                Width = 3, Height = 7
+                            }
+                        },
+                        { "magazine", new SimpleImageModel.Sprite()
+                            {
+                                X = 180, Y = 82,
+                                Width = 11, Height = 15
+                            }
+                        }
+                    }
+                }
+            },
+            {"EQUIP1M", new SimpleImageModel.SpriteSheetData()
+                    {
+                        Sprites = new Dictionary<string, SimpleImageModel.Sprite>() {
+                        { "gun_box", new SimpleImageModel.Sprite()
+                            {
+                                X = 2, Y = 15,
+                                Width = 61, Height = 25
+                            }
+                        },
+                        { "camera_box", new SimpleImageModel.Sprite()
+                            {
+                                X = 2, Y = 54,
+                                Width = 61, Height = 19
+                            }
+                        },
+                        { "bugs_box", new SimpleImageModel.Sprite()
+                            {
+                                X = 2, Y = 88,
+                                Width = 61, Height = 18
+                            }
+                        },
+                        { "grenades_frag_box", new SimpleImageModel.Sprite()
+                            {
+                                X = 2, Y = 122,
+                                Width = 61, Height = 17
+                            }
+                        },
+                        { "grenades_gas_box", new SimpleImageModel.Sprite()
+                            {
+                                X = 2, Y = 140,
+                                Width = 61, Height = 15
+                            }
+                        },
+                        { "grenades_flash_box", new SimpleImageModel.Sprite()
+                            {
+                                X = 2, Y = 156,
+                                Width = 61, Height = 15
+                            }
+                        },
+                        { "grenades_mix_box", new SimpleImageModel.Sprite()
+                            {
+                                X = 2, Y = 172,
+                                Width = 61, Height = 15
+                            }
+                        },
+                        { "gas_mask_box", new SimpleImageModel.Sprite()
+                            {
+                                X = 69, Y = 15,
+                                Width = 45, Height = 36
+                            }
+                        },
+                        { "motion_box", new SimpleImageModel.Sprite()
+                            {
+                                X = 116, Y = 15,
+                                Width = 42, Height = 36
+                            }
+                        },
+                        { "armor_box", new SimpleImageModel.Sprite()
+                            {
+                                X = 69, Y = 60,
+                                Width = 89, Height = 67
+                            }
+                        },
+                        { "safe_box", new SimpleImageModel.Sprite()
+                            {
+                                X = 69, Y = 136,
+                                Width = 89, Height = 45
+                            }
+                        },
+                        { "gun", new SimpleImageModel.Sprite()
+                            {
+                                X = 172, Y = 46,
+                                Width = 59, Height = 23
+                            }
+                        },
+                        { "pistol", new SimpleImageModel.Sprite()
+                            {
+                                X = 176, Y = 48,
+                                Width = 28, Height = 14
+                            }
+                        },
+                        { "camera", new SimpleImageModel.Sprite()
+                            {
+                                X = 221, Y = 75,
+                                Width = 25, Height = 22
+                            }
+                        },
+                        { "camera_text", new SimpleImageModel.Sprite()
+                            {
+                                X = 223, Y = 89,
+                                Width = 15, Height = 9
+                            }
+                        },
+                        { "bugs", new SimpleImageModel.Sprite()
+                            {
+                                X = 291, Y = 4,
+                                Width = 16, Height = 33
+                            }
+                        },
+                        { "grenade_frag", new SimpleImageModel.Sprite()
+                            {
+                                X = 175, Y = 0,
+                                Width = 9, Height = 13
+                            }
+                        },
+                        { "grenade_gas", new SimpleImageModel.Sprite()
+                            {
+                                X = 175, Y = 15,
+                                Width = 9, Height = 13
+                            }
+                        },
+                        { "grenade_flash", new SimpleImageModel.Sprite()
+                            {
+                                X = 175, Y = 30,
+                                Width = 9, Height = 13
+                            }
+                        },
+                        { "gas_mask", new SimpleImageModel.Sprite()
+                            {
+                                X = 253, Y = 2,
+                                Width = 38, Height = 31
+                            }
+                        },
+                        { "motion", new SimpleImageModel.Sprite()
+                            {
+                                X = 268, Y = 1,
+                                Width = 10, Height = 18
+                            }
+                        },
+                        { "armor", new SimpleImageModel.Sprite()
+                            {
+                                X = 253, Y = 29,
+                                Width = 48, Height = 62
+                            }
+                        },
+                        { "safe", new SimpleImageModel.Sprite()
+                            {
+                                X = 264, Y = 69,
+                                Width = 54, Height = 27
+                            }
+                        },
+                        { "bullet", new SimpleImageModel.Sprite()
+                            {
+                                X = 180, Y = 72,
+                                Width = 3, Height = 7
+                            }
+                        },
+                        { "magazine", new SimpleImageModel.Sprite()
+                            {
+                                X = 180, Y = 82,
+                                Width = 11, Height = 15
+                            }
+                        }
+                    }
+                }
+            },
+            {"EQUIP2", new SimpleImageModel.SpriteSheetData()
+                {
+                    //most sprites on the image are not used
+                    //bullets/magazines are duplicated
+                    //grenades are duplicated
+                    //boxes get highlighted by replacing colours, not by placing the sprite in
+                    Sprites = new Dictionary<string, SimpleImageModel.Sprite>()
+                    {
+                        { "gun_box", new SimpleImageModel.Sprite()
+                            {
+                                X = 2, Y = 15,
+                                Width = 61, Height = 25
+                            }
+                        },
+                        { "camera_box", new SimpleImageModel.Sprite()
+                            {
+                                X = 2, Y = 54,
+                                Width = 61, Height = 19
+                            }
+                        },
+                        { "bugs_box", new SimpleImageModel.Sprite()
+                            {
+                                X = 2, Y = 88,
+                                Width = 61, Height = 18
+                            }
+                        },
+                        { "grenades_frag_box", new SimpleImageModel.Sprite()
+                            {
+                                X = 2, Y = 122,
+                                Width = 61, Height = 17
+                            }
+                        },
+                        { "grenades_gas_box", new SimpleImageModel.Sprite()
+                            {
+                                X = 2, Y = 140,
+                                Width = 61, Height = 15
+                            }
+                        },
+                        { "grenades_flash_box", new SimpleImageModel.Sprite()
+                            {
+                                X = 2, Y = 156,
+                                Width = 61, Height = 15
+                            }
+                        },
+                        { "grenades_mix_box", new SimpleImageModel.Sprite()
+                            {
+                                X = 2, Y = 172,
+                                Width = 61, Height = 15
+                            }
+                        },
+                        { "gas_mask_box", new SimpleImageModel.Sprite()
+                            {
+                                X = 69, Y = 15,
+                                Width = 45, Height = 36
+                            }
+                        },
+                        { "motion_box", new SimpleImageModel.Sprite()
+                            {
+                                X = 116, Y = 15,
+                                Width = 42, Height = 36
+                            }
+                        },
+                        { "armor_box", new SimpleImageModel.Sprite()
+                            {
+                                X = 69, Y = 60,
+                                Width = 89, Height = 67
+                            }
+                        },
+                        { "safe_box", new SimpleImageModel.Sprite()
+                            {
+                                X = 69, Y = 136,
+                                Width = 89, Height = 45
+                            }
+                        },
+                        { "gun", new SimpleImageModel.Sprite()
+                            {
+                                X = 162, Y = 71,
+                                Width = 59, Height = 23
+                            }
+                        },
+                        { "pistol", new SimpleImageModel.Sprite()
+                            {
+                                X = 162, Y = 25,
+                                Width = 28, Height = 14
+                            }
+                        },
+                        { "camera", new SimpleImageModel.Sprite()
+                            {
+                                X = 272, Y = 101,
+                                Width = 25, Height = 22
+                            }
+                        },
+                        { "bugs", new SimpleImageModel.Sprite()
+                            {
+                                X = 303, Y = 41,
+                                Width = 16, Height = 33
+                            }
+                        },
+                        { "grenade_frag", new SimpleImageModel.Sprite()
+                            {
+                                X = 285, Y = 137,
+                                Width = 9, Height = 13
+                            }
+                        },
+                        { "grenade_gas", new SimpleImageModel.Sprite()
+                            {
+                                X = 285, Y = 152,
+                                Width = 9, Height = 13
+                            }
+                        },
+                        { "grenade_flash", new SimpleImageModel.Sprite()
+                            {
+                                X = 285, Y = 167,
+                                Width = 9, Height = 13
+                            }
+                        },
+                        { "gas_mask", new SimpleImageModel.Sprite()
+                            {
+                                X = 254, Y = 1,
+                                Width = 38, Height = 31
+                            }
+                        },
+                        { "motion", new SimpleImageModel.Sprite()
+                            {
+                                X = 246, Y = 41,
+                                Width = 10, Height = 18
+                            }
+                        },
+                        { "armor", new SimpleImageModel.Sprite()
+                            {
+                                X = 223, Y = 71,
+                                Width = 48, Height = 62
+                            }
+                        },
+                        { "safe", new SimpleImageModel.Sprite()
+                            {
+                                X = 220, Y = 172,
+                                Width = 54, Height = 27
+                            }
+                        },
+                        { "bullet", new SimpleImageModel.Sprite()
+                            {
+                                X = 201, Y = 41,
+                                Width = 3, Height = 7
+                            }
+                        },
+                        { "magazine", new SimpleImageModel.Sprite()
+                            {
+                                X = 188, Y = 41,
+                                Width = 11, Height = 15
+                            }
+                        },
+                        { "target", new SimpleImageModel.Sprite()
+                            {
+                                X = 298, Y = 101,
+                                Width = 15, Height = 13
+                            }
+                        },
+                        { "injury", new SimpleImageModel.Sprite()
+                            {
+                                X = 162, Y = 95,
+                                Width = 9, Height = 7
+                            }
+                        }
+                    }
+                }
+            },
+            //"FACES",
+            //"FACESF",
+            //"GUYS2",
+            //"GUYS3",
+            //"ICONS",
+            //"SPRITES",
+            //"SPRITESF",
+            //"STREET"
+        };
+        #endregion
+        
         private readonly ILogger<LegacySimpleImageParser> _logger;
         private readonly SharedImageParser _imageParser;
         
@@ -89,10 +591,17 @@ namespace CovertActionTools.Core.Importing.Parsers
             {
                 _logger.LogWarning($"Loading image {key} data ended at offset {memStream.Position:X} but length was {rawData.Length:X}");
             }
+
+            SimpleImageModel.SpriteSheetData? spriteSheet = null;
+            if (LegacySpriteSheets.TryGetValue(key, out var defaultSpriteSheet))
+            {
+                spriteSheet = defaultSpriteSheet.Clone();
+            }
             return new SimpleImageModel()
             {
                 Key = key,
                 Image = image,
+                SpriteSheet = spriteSheet,
                 Metadata = new SharedMetadata()
                 {
                     Name = key,

--- a/src/CovertActionTools.Core/Models/SimpleImageModel.cs
+++ b/src/CovertActionTools.Core/Models/SimpleImageModel.cs
@@ -1,7 +1,42 @@
-﻿namespace CovertActionTools.Core.Models
+﻿using System.Collections.Generic;
+using System.Linq;
+
+namespace CovertActionTools.Core.Models
 {
     public class SimpleImageModel
     {
+        public class Sprite
+        {
+            public int X { get; set; }
+            public int Y { get; set; }
+            public int Width { get; set; }
+            public int Height { get; set; }
+
+            public Sprite Clone()
+            {
+                return new Sprite()
+                {
+                    X = X,
+                    Y = Y,
+                    Width = Width,
+                    Height = Height
+                };
+            }
+        }
+
+        public class SpriteSheetData
+        {
+            public Dictionary<string, Sprite> Sprites { get; set; } = new();
+
+            public SpriteSheetData Clone()
+            {
+                return new SpriteSheetData()
+                {
+                    Sprites = Sprites.ToDictionary(x => x.Key, x => x.Value.Clone())
+                };
+            }
+        }
+        
         /// <summary>
         /// ID that also determines the filename
         /// </summary>
@@ -9,6 +44,12 @@
 
         public SharedMetadata Metadata { get; set; } = new();
         public SharedImageModel Image { get; set; } = new();
+        /// <summary>
+        /// Sprite sheet information for which sprites exist on the image
+        /// For legacy images, this data will not cover ALL sprites on the sheet because
+        /// a good deal of them are not used by the game.
+        /// </summary>
+        public SpriteSheetData? SpriteSheet { get; set; } = null;
 
         public SimpleImageModel Clone()
         {
@@ -16,7 +57,8 @@
             {
                 Key = Key,
                 Metadata = Metadata.Clone(),
-                Image = Image.Clone()
+                Image = Image.Clone(),
+                SpriteSheet = SpriteSheet?.Clone()
             };
         }
     }


### PR DESCRIPTION
Adds sprite sheet handling to images, which allows particular rectangles in the images to be given a key. This is not used in the game, but can be used by anything that reads the package data. This can be used to define a position to place something else onto, or as something to copy/draw from.

EQUIP1/EQUIP1M/EQUIP2 have had their sprite definitions added (based on the sprites the game engine actually uses). Interesting to note that a lot of the sprites on the image are not actually used by the game.